### PR TITLE
Redirect logged in users to events page

### DIFF
--- a/app/controllers/meetup_controller.rb
+++ b/app/controllers/meetup_controller.rb
@@ -1,5 +1,6 @@
 class MeetupController < ApplicationController
   def home
+    redirect_to events_path unless session.blank?
   end
 
   def callback


### PR DESCRIPTION
When a logged in user tries to access the login page again, we should redirect it to the events page instead.

Solves #9.