### PR TITLE
Update home redirect to only if its logged

### DIFF
--- a/app/controllers/meetup_controller.rb
+++ b/app/controllers/meetup_controller.rb
@@ -1,6 +1,6 @@
 class MeetupController < ApplicationController
   def home
-    redirect_to events_path unless session.blank?
+    redirect_to events_path unless session[:auth].blank?
   end
 
   def callback


### PR DESCRIPTION
When a user enter the site and for some reason don't log-in, he gets an error, since the user would already have a session, but not the meetup login.